### PR TITLE
Replace ebnf definition by a table

### DIFF
--- a/pages/content/ch2/propositional-logic.mdx
+++ b/pages/content/ch2/propositional-logic.mdx
@@ -67,6 +67,8 @@ $\vDash$
   | `Proposition`      | `FormulaStatement` **│** `Statement` **│** `PropSymbol` **│** Mathematical&nbsp;statement                |
   | `Statement`        | `FormulaStatement` **│** `Proposition` **(**`StatementOp` `Proposition` **│** $\text{is false}$**)**     |
 
+  You can try it out in the [EBNF Lab](https://thomasgassmann.com/ebnf?rules=%3Cwhitespace%3E+%3C%3D+%7B%22+%22%7D%0A%3CPropSymbol%3E+%3C%3D+A%7CB%7CC%7CD%7CE%7CF%7CG%7CH%7CI%7CJ%7CK%7CL%7CM%7CN%7CO%7CP%7CQ%7CR%7CS%7CT%7CU%7CV%7CW%7CX%7CY%7CZ%0A%3CSymbol%3E+%3C%3D+%3CPropSymbol%3E%7C%E2%8A%A4%7C%E2%8A%A5%0A%3CLogicOp%3E+%3C%3D+%3Cwhitespace%3E%28%E2%88%A7%7C%E2%88%A8%7Cv%7C%E2%86%94%7C%E2%86%92%29%3Cwhitespace%3E%0A%3CNegation%3E+%3C%3D+%C2%AC%0A%3CCombination%3E+%3C%3D+%28%3CFormula%3E+%7C+%22%28%22%3CCombination%3E%22%29%22%29+%3CLogicOp%3E+%28%3CFormula%3E+%7C+%22%28%22%3CCombination%3E%22%29%22%29%0A%3CFormula%3E+%3C%3D+%5B%3CNegation%3E%5D%3CSymbol%3E+%7C+%3CCombination%3E+%7C+%3CNegation%3E%22%28%22%3CCombination%3E%22%29%22%0A%3CFormulaStatement%3E+%3C%3D+%3CFormula%3E+%3Cwhitespace%3E%28%E2%89%A1%7C%E2%8A%A8%29%3Cwhitespace%3E+%3CFormula%3E+%7C+%E2%8A%A8%3Cwhitespace%3E+%3CFormula%3E%0A%3CStatementOp%3E+%3C%3D+%3Cwhitespace%3E%28%E2%87%92%7C%E2%9F%B9%7C%E2%87%94%7C%E2%9F%BA%29%3Cwhitespace%3E+%7C+%22+and+%22+%7C+%22+or+%22%0A%3CProposition%3E+%3C%3D+%3CFormulaStatement%3E+%7C+%3CStatement%3E+%7C+%3CPropSymbol%3E+%7C+%22Mathematical+statement%22%0A%3CStatement%3E+%3C%3D+%3CFormulaStatement%3E+%7C+%3CProposition%3E+%28%3CStatementOp%3E+%3CProposition%3E+%7C+%22+is+false%22%29&content=S+is+false%0AA%E2%88%A7B%E2%89%A1C%0AS+%E2%9F%B9+T).
+
 </div>
 
 ## Exercises

--- a/pages/content/ch2/propositional-logic.mdx
+++ b/pages/content/ch2/propositional-logic.mdx
@@ -50,41 +50,24 @@ $\vDash$
 
 ## EBNF: Statements vs Formulas
 
-This tries to define formulas and statements with EBNF. Note that all literals are in double quotes.
+<div className="mt-4 [&_code]:font-[inherit] [&_code]:italic">
 
-$$
-\begin{aligned}
-\textit{Symbol} & \Leftarrow \text{A-Z} \\
-\\
-\textit{LogicalOperator} & \Leftarrow \text{"} \land \text{"} \\
-       & \quad \vert \; \text{"} \leftrightarrow \text{"} \\
-       & \quad \vert \; \text{"} \lor \text{"} \\
-       & \quad \vert \; \text{"} \to \text{"} \\
-       & \quad \vert \; \text{"} \lnot \text{"} \\
-\\  
-\textit{FormulaToStatementOperator} & \Leftarrow \text{"} \equiv \text{"} \\
-       & \quad \vert \; \text{"} \models \text{"} \\
-\\
-\textit{StatementOperator} & \Leftarrow \text{"} \implies \text{"} \\
-       & \quad \vert \; \text{"} \iff \text{"} \\
-       & \quad \vert \; \text{"and"} \\
-       & \quad \vert \; \text{"or"} \\
-\\   
-\textit{Formula} & \Leftarrow \textit{Symbol} \\
-       & \quad \vert \; \textit{Symbol } \textit{ LogicalOperator } \textit{ Symbol} \\
-       & \quad \vert \; "("\textit{Formula } \textit{ LogicalOperator } \textit{ Formula}")" \\
-       & \quad \vert \; \text{"} \top \text{"} \\
-       & \quad \vert \; \text{"} \bot \text{"} \\
-\\   
-\textit{Statement} & \Leftarrow \textit{Symbol} \\
-       & \quad \vert \; \textit{Statement } \textit{ StatementOperator } \textit{ Statement} \\
-       & \quad \vert \; \textit{Statement } \text{ "is false"} \\
-       & \quad \vert \; \textit{Formula } \textit{ FormulaToStatementOperator } \textit{ Formula} \\
-       & \quad \vert \; \text{"} \models \text{"} \textit{ Formula} \\
-\end{aligned}
-$$
+  This tries to define formulas and statements with EBNF. Bold symbols are used to denote EBNF syntax elements **(** **)** **\[** **]** **│**. References to existing rules are made using `Rulename…` element.
 
+  | Rule                | Expression                                                                                                 |
+  |---------------------|------------------------------------------------------------------------------------------------------------|
+  | `PropSymbol`        | $A$ **│** $B$ **│** $C$ **│** ••• **│** $Z$                                                                |
+  | `Symbol`            | `PropSymbol` **│** $\top$ **│** $\bot$                                                                     |
+  | `LogicOperator`     | $\land$ **│** $\lor$ **│** $\leftrightarrow$ **│** $\to$                                                   |
+  | `Negation`          | $\lnot$                                                                                                    |
+  | `Combination`       | **(**`Formula` **│** $($`Combination`$)$**)** `Operator` **(**`Formula` **│** $($`Combination`$)$**)**     |
+  | `Formula`           | **[**`Negation`**]**`Symbol` **│** `Combination` **│** `Negation`$($`Combination`$)$                       |
+  | `FormulaStatement`  | `Formula` **(** $\equiv$ **│** $\models$ **)** `Formula` **│** $\models$ `Formula`                         |
+  | `StatementOperator` | $\implies$ **│** $\iff$ **│** $\text{ and }$ **│** $\text{ or }$                                           |
+  | `Proposition`       | `FormulaStatement` **│** `Statement` **│** `PropSymbol`&nbsp;or&nbsp;mathematical&nbsp;statement           |
+  | `Statement`         | `FormulaStatement` **│** `Proposition` **(**`StatementOperator` `Proposition` **│** $\text{is false}$**)** |
 
+</div>
 
 ## Exercises
 

--- a/pages/content/ch2/propositional-logic.mdx
+++ b/pages/content/ch2/propositional-logic.mdx
@@ -54,18 +54,18 @@ $\vDash$
 
   This tries to define formulas and statements with EBNF. Bold symbols are used to denote EBNF syntax elements **(** **)** **\[** **]** **│**. References to existing rules are made using `Rulename…` element.
 
-  | Rule                | Expression                                                                                                 |
-  |---------------------|------------------------------------------------------------------------------------------------------------|
-  | `PropSymbol`        | $A$ **│** $B$ **│** $C$ **│** ••• **│** $Z$                                                                |
-  | `Symbol`            | `PropSymbol` **│** $\top$ **│** $\bot$                                                                     |
-  | `LogicOperator`     | $\land$ **│** $\lor$ **│** $\leftrightarrow$ **│** $\to$                                                   |
-  | `Negation`          | $\lnot$                                                                                                    |
-  | `Combination`       | **(**`Formula` **│** $($`Combination`$)$**)** `Operator` **(**`Formula` **│** $($`Combination`$)$**)**     |
-  | `Formula`           | **[**`Negation`**]**`Symbol` **│** `Combination` **│** `Negation`$($`Combination`$)$                       |
-  | `FormulaStatement`  | `Formula` **(** $\equiv$ **│** $\models$ **)** `Formula` **│** $\models$ `Formula`                         |
-  | `StatementOperator` | $\implies$ **│** $\iff$ **│** $\text{ and }$ **│** $\text{ or }$                                           |
-  | `Proposition`       | `FormulaStatement` **│** `Statement` **│** `PropSymbol`&nbsp;or&nbsp;mathematical&nbsp;statement           |
-  | `Statement`         | `FormulaStatement` **│** `Proposition` **(**`StatementOperator` `Proposition` **│** $\text{is false}$**)** |
+  | Rule               | Expression                                                                                               |
+  |--------------------|----------------------------------------------------------------------------------------------------------|
+  | `PropSymbol`       | $A$ **│** $B$ **│** $C$ **│** ••• **│** $Z$                                                              |
+  | `Symbol`           | `PropSymbol` **│** $\top$ **│** $\bot$                                                                   |
+  | `LogicOp`          | $\land$ **│** $\lor$ **│** $\leftrightarrow$ **│** $\to$                                                 |
+  | `Negation`         | $\lnot$                                                                                                  |
+  | `Combination`      | **(**`Formula` **│** $($`Combination`$)$**)** `LogicOp` **(**`Formula` **│** $($`Combination`$)$**)**    |
+  | `Formula`          | **[**`Negation`**]**`Symbol` **│** `Combination` **│** `Negation`$($`Combination`$)$                     |
+  | `FormulaStatement` | `Formula` **(** $\equiv$ **│** $\models$ **)** `Formula` **│** $\models$ `Formula`                       |
+  | `StatementOp`      | $\implies$ **│** $\iff$ **│** $\text{ and }$ **│** $\text{ or }$                                         |
+  | `Proposition`      | `FormulaStatement` **│** `Statement` **│** `PropSymbol` **│** Mathematical&nbsp;statement                |
+  | `Statement`        | `FormulaStatement` **│** `Proposition` **(**`StatementOp` `Proposition` **│** $\text{is false}$**)**     |
 
 </div>
 


### PR DESCRIPTION
The current ebnf definition does not correctly capture the negation and braces. I've changed the latex align definition with a table to improve the structure.